### PR TITLE
Added `no-deprecated-vue-extend` rule.

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -66,6 +66,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/no-deprecated-v-on-native-modifier](./no-deprecated-v-on-native-modifier.md) | disallow using deprecated `.native` modifiers (in Vue.js 3.0.0+) |  | :three::warning: |
 | [vue/no-deprecated-v-on-number-modifiers](./no-deprecated-v-on-number-modifiers.md) | disallow using deprecated number (keycode) modifiers (in Vue.js 3.0.0+) | :wrench: | :three::warning: |
 | [vue/no-deprecated-vue-config-keycodes](./no-deprecated-vue-config-keycodes.md) | disallow using deprecated `Vue.config.keyCodes` (in Vue.js 3.0.0+) |  | :three::warning: |
+| [vue/no-deprecated-vue-extend](./no-deprecated-vue-extend.md) | disallow using deprecated `Vue.extend` (in Vue.js 3.0.0+) |  | :three::warning: |
 | [vue/no-dupe-keys](./no-dupe-keys.md) | disallow duplication of field names |  | :three::two::warning: |
 | [vue/no-dupe-v-else-if](./no-dupe-v-else-if.md) | disallow duplicate conditions in `v-if` / `v-else-if` chains |  | :three::two::warning: |
 | [vue/no-duplicate-attributes](./no-duplicate-attributes.md) | disallow duplication of attributes |  | :three::two::warning: |

--- a/docs/rules/no-deprecated-vue-extend.md
+++ b/docs/rules/no-deprecated-vue-extend.md
@@ -1,0 +1,66 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-deprecated-vue-extend
+description: disallow using deprecated `Vue.extend` (in Vue.js 3.0.0+)
+---
+# vue/no-deprecated-vue-extend
+
+> disallow using deprecated `Vue.extend` (in Vue.js 3.0.0+)
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/vue3-strongly-recommended"` and `"plugin:vue/vue3-recommended"`.
+
+## :book: Rule Details
+
+This rule reports deprecated `Vue.extend` (removed in Vue.js v3.0.0+).
+
+See [Migration Guide - Global API Application Instance](https://v3-migration.vuejs.org/breaking-changes/global-api.html#vue-extend-removed) for more details.
+
+<eslint-code-block :rules="{'vue/no-deprecated-vue-extend': ['error']}">
+
+```js
+<!-- ✓ GOOD -->
+const Profile = {/* */}
+
+<!-- ✗ BAD -->
+const Profile = Vue.extend({ /* */ })
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-deprecated-vue-extend': ['error']}">
+
+```vue
+<!-- ✓ GOOD -->
+<script>
+import { defineComponent } from 'vue'
+export default defineComponent({
+  /* */
+})
+</script>
+
+<!-- ✗ BAD -->
+<script>
+import Vue from 'vue'
+export default Vue.extend({
+  /* */
+})
+</script>
+```
+
+</eslint-code-block>
+
+### :wrench: Options
+
+Nothing.
+
+## :books: Further Reading
+
+- [Migration Guide - Global API Application Instance](https://v3-migration.vuejs.org/breaking-changes/global-api.html#vue-extend-removed)
+- [Vue RFCs - 0009-global-api-change.md](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0009-global-api-change.md)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-deprecated-vue-extend.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-deprecated-vue-extend.js)

--- a/lib/configs/vue3-essential.js
+++ b/lib/configs/vue3-essential.js
@@ -30,6 +30,7 @@ module.exports = {
     'vue/no-deprecated-v-on-native-modifier': 'error',
     'vue/no-deprecated-v-on-number-modifiers': 'error',
     'vue/no-deprecated-vue-config-keycodes': 'error',
+    'vue/no-deprecated-vue-extend': 'error',
     'vue/no-dupe-keys': 'error',
     'vue/no-dupe-v-else-if': 'error',
     'vue/no-duplicate-attributes': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,7 @@ module.exports = {
     'no-deprecated-v-on-native-modifier': require('./rules/no-deprecated-v-on-native-modifier'),
     'no-deprecated-v-on-number-modifiers': require('./rules/no-deprecated-v-on-number-modifiers'),
     'no-deprecated-vue-config-keycodes': require('./rules/no-deprecated-vue-config-keycodes'),
+    'no-deprecated-vue-extend': require('./rules/no-deprecated-vue-extend'),
     'no-dupe-keys': require('./rules/no-dupe-keys'),
     'no-dupe-v-else-if': require('./rules/no-dupe-v-else-if'),
     'no-duplicate-attr-inheritance': require('./rules/no-duplicate-attr-inheritance'),

--- a/lib/rules/no-deprecated-vue-extend.js
+++ b/lib/rules/no-deprecated-vue-extend.js
@@ -1,0 +1,38 @@
+/**
+ * @author Madogiwa(@madogiwa0124)
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow using deprecated `Vue.extend` (in Vue.js 3.0.0+)',
+      categories: ['vue3-essential'],
+      url: 'https://eslint.vuejs.org/rules/no-deprecated-vue-extend.html'
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noDeprecatedVueExtend: '`Vue.extend` are deprecated.'
+    }
+  },
+  /** @param {RuleContext} context */
+  create(context) {
+    return {
+      /** @param {CallExpression} node */
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.object.name === 'Vue' &&
+          node.callee.property.name === 'extend'
+        ) {
+          context.report({ node, messageId: 'noDeprecatedVueExtend' })
+        }
+      }
+    }
+  }
+}

--- a/tests/lib/rules/no-deprecated-vue-extend.js
+++ b/tests/lib/rules/no-deprecated-vue-extend.js
@@ -1,0 +1,56 @@
+/**
+ * @author Madogiwa(@madogiwa0124)
+ * See LICENSE file in root directory for full license.
+ */
+
+'use strict'
+const rule = require('../../../lib/rules/no-deprecated-vue-extend')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
+})
+
+ruleTester.run('no-deprecated-vue-config-keycodes', rule, {
+  valid: [
+    {
+      filename: 'test.js',
+      code: `const Profile = {}`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          import { defineComponent } from 'vue'
+          export default defineComponent({})
+        </script>
+      `
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.js',
+      code: `const Profile = Vue.extend({})`,
+      errors: [
+        {
+          message: '`Vue.extend` are deprecated.'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          import Vue from 'vue'
+          export default Vue.extend({})
+        </script>
+      `,
+      errors: [
+        {
+          message: '`Vue.extend` are deprecated.'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
`Vue.extend` is removed in Vue.js 3.0.0+.

> Vue.extend Removed
> https://v3-migration.vuejs.org/breaking-changes/global-api.html#vue-extend-removed

This rule checks for disallow using deprecated `Vue.extend`.